### PR TITLE
Project contributor authorization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,6 +70,7 @@ group :development do
 end
 
 group :test do
+  gem 'factory_bot_rails'
   gem 'rspec-rails', '~> 3.7'
   gem 'visdiff', github: 'sinetheta/visdiff-ruby', branch: 'master'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,7 @@ gem 'aws-sdk-s3', require: false
 gem 'capybara'
 gem 'webdrivers'
 gem 'devise'
+gem 'pundit', '~> 2.1'
 gem 'selenium-webdriver'
 
 # ENV management

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -101,6 +101,11 @@ GEM
       unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     execjs (2.7.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.13.1)
@@ -314,6 +319,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   capybara
   devise
+  factory_bot_rails
   figaro
   jbuilder (~> 2.5)
   letter_opener

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,6 +175,8 @@ GEM
       pry (>= 0.10.4)
     public_suffix (3.0.2)
     puma (3.11.4)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.0.5)
     rack-proxy (0.6.4)
       rack
@@ -321,6 +323,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 3.11)
+  pundit (~> 2.1)
   rails (~> 5.2.0)
   rails_real_favicon
   react-rails

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,7 @@
 class ApplicationController < ActionController::Base
   include Pundit
+  after_action :verify_authorized, except: :index
+  after_action :verify_policy_scoped, only: :index
+
   protect_from_forgery with: :reset_session
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
+  include Pundit
   protect_from_forgery with: :reset_session
 end

--- a/app/controllers/project_tokens_controller.rb
+++ b/app/controllers/project_tokens_controller.rb
@@ -1,6 +1,7 @@
 class ProjectTokensController < ApplicationController
   def create
     token = ProjectToken.create(project_token_params)
+    authorize token
     redirect_to token.project
   end
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -19,7 +19,6 @@ class ProjectsController < ApplicationController
   end
 
   def update
-    authorize @project
     @project.update(project_params)
     render :show
   end
@@ -28,6 +27,7 @@ class ProjectsController < ApplicationController
 
   def load_project
     @project = Project.find(params[:id])
+    authorize @project
   end
 
   def project_params

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -3,6 +3,7 @@ class ProjectsController < ApplicationController
 
   def create
     @project = Project.create(project_params)
+    authorize @project
     render :show
   end
 
@@ -12,6 +13,7 @@ class ProjectsController < ApplicationController
 
   def new
     @project = Project.new
+    authorize @project
   end
 
   def update

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -17,6 +17,7 @@ class ProjectsController < ApplicationController
   end
 
   def update
+    authorize @project
     @project.update(project_params)
     render :show
   end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -7,7 +7,7 @@ class ProjectsController < ApplicationController
   end
 
   def index
-    @projects = Project.all
+    @projects = policy_scope(Project)
   end
 
   def new

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -2,7 +2,9 @@ class ProjectsController < ApplicationController
   before_action :load_project, only: [:edit, :show, :update]
 
   def create
-    @project = Project.create(project_params)
+    @project = Project.new(project_params)
+    @project.members.new(user: current_user, role: :admin)
+    @project.save!
     authorize @project
     render :show
   end

--- a/app/controllers/scenarios_controller.rb
+++ b/app/controllers/scenarios_controller.rb
@@ -4,6 +4,7 @@ class ScenariosController < ApplicationController
 
   def create
     @scenario = @project.scenarios.create(scenario_params)
+    authorize @scenario
     render :show
   end
 
@@ -14,12 +15,13 @@ class ScenariosController < ApplicationController
   end
 
   def index
-    @scenarios = @project.scenarios
+    @scenarios = policy_scope(Scenario)
   end
 
   def new
     @scenario = @project.scenarios.new
     @scenario.script = NavigationScript.new
+    authorize @scenario
   end
 
   def update
@@ -28,6 +30,7 @@ class ScenariosController < ApplicationController
   end
 
   def run
+    authorize @scenario
     require 'whattheshift/scripting/revision_from_scenario'
     runner = WhatTheShift::Scripting::RevisionFromScenario.new(capybara_driver, @scenario)
     revision = runner.call(run_params[:description])
@@ -48,6 +51,7 @@ class ScenariosController < ApplicationController
 
   def load_scenario
     @scenario = Scenario.includes(:script).find(params[:id])
+    authorize @scenario
   end
 
   def scenario_params

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Users::ConfirmationsController < Devise::ConfirmationsController
+  skip_after_action :verify_authorized
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,4 +1,6 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_after_action :verify_authorized
+
   def github
     user = User.from_omniauth(request.env['omniauth.auth'])
     user.link_account_from_omniauth(request.env['omniauth.auth'])

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  skip_after_action :verify_authorized
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  skip_after_action :verify_authorized
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  skip_after_action :verify_authorized
 end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 class Users::UnlocksController < Devise::UnlocksController
+  skip_after_action :verify_authorized
 end

--- a/app/controllers/welcome_controller.rb
+++ b/app/controllers/welcome_controller.rb
@@ -1,4 +1,7 @@
 class WelcomeController < ApplicationController
+  skip_after_action :verify_authorized
+  skip_after_action :verify_policy_scoped
+
   def index
     @comparisons = Comparison.includes(
         image_diffs: [:after_image, :before_image],

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,4 +1,5 @@
 class Project < ApplicationRecord
+  has_many :members, class_name: 'ProjectMember'
   has_many :project_tokens
   has_many :scenarios
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,49 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -46,4 +46,11 @@ class ApplicationPolicy
       scope.all
     end
   end
+
+  private
+
+  def ensure_login!
+    raise Pundit::NotAuthorizedError, "must be logged in" unless user
+    true
+  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -1,4 +1,8 @@
 class ProjectPolicy < ApplicationPolicy
+  def create?
+    ensure_login!
+  end
+
   def index?
     true
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -12,6 +12,12 @@ class ProjectPolicy < ApplicationPolicy
   end
 
   def update?
+    contributor?
+  end
+
+  private
+
+  def contributor?
     ProjectMember.where(project: record, user: user, role: [:admin, :member]).any?
   end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -1,4 +1,8 @@
 class ProjectPolicy < ApplicationPolicy
+  def admin_tokens?
+    contributor?
+  end
+
   def create?
     ensure_login!
   end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -6,4 +6,8 @@ class ProjectPolicy < ApplicationPolicy
   def show?
     true
   end
+
+  def update?
+    ProjectMember.where(project: record, user: user, role: [:admin, :member]).any?
+  end
 end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -1,0 +1,5 @@
+class ProjectPolicy < ApplicationPolicy
+  def show?
+    ProjectMember.where(project: record, user: user, role: [:admin, :member]).any?
+  end
+end

--- a/app/policies/project_policy.rb
+++ b/app/policies/project_policy.rb
@@ -1,5 +1,9 @@
 class ProjectPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
   def show?
-    ProjectMember.where(project: record, user: user, role: [:admin, :member]).any?
+    true
   end
 end

--- a/app/policies/project_token_policy.rb
+++ b/app/policies/project_token_policy.rb
@@ -1,0 +1,11 @@
+class ProjectTokenPolicy < ApplicationPolicy
+  def create?
+    contributor?
+  end
+
+  private
+
+  def contributor?
+    ProjectMember.where(project: record.project, user: user, role: [:admin, :member]).any?
+  end
+end

--- a/app/policies/revision_policy.rb
+++ b/app/policies/revision_policy.rb
@@ -1,0 +1,9 @@
+class RevisionPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+end

--- a/app/policies/scenario_policy.rb
+++ b/app/policies/scenario_policy.rb
@@ -1,0 +1,31 @@
+class ScenarioPolicy < ApplicationPolicy
+  def create?
+    contributor?
+  end
+
+  def destroy?
+    contributor?
+  end
+
+  def index?
+    contributor?
+  end
+
+  def run?
+    contributor?
+  end
+
+  def show?
+    contributor?
+  end
+
+  def update?
+    contributor?
+  end
+
+  private
+
+  def contributor?
+    ProjectMember.where(project: record.project, user: user, role: [:admin, :member]).any?
+  end
+end

--- a/app/views/projects/_admin_tokens.html.erb
+++ b/app/views/projects/_admin_tokens.html.erb
@@ -1,0 +1,5 @@
+<% if policy(project).admin_tokens? %>
+  <h2>Api Keys</h2>
+  <%= render partial: '/project_tokens/list', locals: { project_tokens: project.project_tokens } %>
+  <%= render partial: '/project_tokens/form', locals: { project: project } %>
+<% end %>

--- a/app/views/projects/show.html.erb
+++ b/app/views/projects/show.html.erb
@@ -10,9 +10,7 @@
   <%= @project.name %>
 </p>
 
-<h2>Api Keys</h2>
-<%= render partial: '/project_tokens/list', locals: { project_tokens: @project.project_tokens } %>
-<%= render partial: '/project_tokens/form', locals: { project: @project } %>
+<%= render partial: '/projects/admin_tokens', locals: { project: @project } %>
 
 <p>
   <%= link_to 'Scenarios', [@project, :scenarios] %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,12 @@ Rails.application.routes.draw do
     resources :images
   end
 
-  devise_for :users, controllers: { omniauth_callbacks: 'users/omniauth_callbacks' }
+  devise_for :users, controllers: {
+    confirmations: 'users/confirmations',
+    omniauth_callbacks: 'users/omniauth_callbacks',
+    passwords: 'users/passwords',
+    registrations: 'users/registrations',
+    sessions: 'users/sessions',
+    unlocks: 'users/unlocks'
+  }
 end

--- a/db/migrate/20201023220724_project_member_role_not_null.rb
+++ b/db/migrate/20201023220724_project_member_role_not_null.rb
@@ -1,0 +1,5 @@
+class ProjectMemberRoleNotNull < ActiveRecord::Migration[5.2]
+  def change
+    change_column_null :project_members, :role, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_17_210058) do
+ActiveRecord::Schema.define(version: 2020_10_23_220724) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -82,7 +82,7 @@ ActiveRecord::Schema.define(version: 2020_10_17_210058) do
   create_table "project_members", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "project_id"
-    t.integer "role"
+    t.integer "role", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["project_id"], name: "index_project_members_on_project_id"

--- a/spec/factories/project_factory.rb
+++ b/spec/factories/project_factory.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :project do
+  end
+end

--- a/spec/factories/project_member.rb
+++ b/spec/factories/project_member.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :project_member do
+    project
+    user
   end
 end

--- a/spec/factories/project_member.rb
+++ b/spec/factories/project_member.rb
@@ -1,0 +1,4 @@
+FactoryBot.define do
+  factory :project_member do
+  end
+end

--- a/spec/factories/project_token_factory.rb
+++ b/spec/factories/project_token_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :project_token do
+    project
+  end
+end

--- a/spec/factories/revision_factory.rb
+++ b/spec/factories/revision_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :revision do
+    scenario
+  end
+end

--- a/spec/factories/scenario_factory.rb
+++ b/spec/factories/scenario_factory.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :scenario do
+    project
+  end
+end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    email { generate(:email) }
+    password { 'secret' }
+    password_confirmation { password }
+  end
+end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -4,11 +4,33 @@ RSpec.describe ProjectPolicy, type: :policy do
   let(:user) { create(:user) }
   let(:record) { create(:project) }
   let(:project_policy) { described_class.new(user, record) }
+
+  describe '#create?' do
+    subject { project_policy.create? }
+
+    it { is_expected.to be(true) }
+  end
   
   describe '#index?' do
     subject { project_policy.index? }
 
     it { is_expected.to be(true) }
+  end
+
+  describe '#new?' do
+    subject { project_policy.new? }
+
+    context 'with logged in user' do
+      let(:user) { create(:user) }
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'without logged in user' do
+      let(:user) { nil }
+
+      it { expect{ subject }.to raise_error(Pundit::NotAuthorizedError) }
+    end
   end
 
   describe '#show?' do

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -27,6 +27,12 @@ RSpec.describe ProjectPolicy, type: :policy do
     end
   end
 
+  describe '#admin_tokens?' do
+    subject { project_policy.admin_tokens? }
+    
+    it_behaves_like 'an action available only to contributors'
+  end
+
   describe '#create?' do
     subject { project_policy.create? }
 

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe ProjectPolicy, type: :policy do
+  let(:user) { create(:user) }
+  let(:record) { create(:project) }
+  let(:project_policy) { described_class.new(user, record) }
+
+  describe '#show?' do
+    subject { project_policy.show? }
+    
+    context 'with no role for for this project' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an admin rolefor for this project' do
+      before do
+        create(:project_member, project: record, user: user, role: :admin)
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'with a member rolefor this project' do
+      before do
+        create(:project_member, project: record, user: user, role: :member)
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
+end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -16,4 +16,28 @@ RSpec.describe ProjectPolicy, type: :policy do
 
     it { is_expected.to be(true) }
   end
+
+  describe '#update?' do
+    subject { project_policy.update? }
+    
+    context 'with no role for for this project' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an admin rolefor for this project' do
+      before do
+        create(:project_member, project: record, user: user, role: :admin)
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'with a member rolefor this project' do
+      before do
+        create(:project_member, project: record, user: user, role: :member)
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
 end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -4,28 +4,16 @@ RSpec.describe ProjectPolicy, type: :policy do
   let(:user) { create(:user) }
   let(:record) { create(:project) }
   let(:project_policy) { described_class.new(user, record) }
+  
+  describe '#index?' do
+    subject { project_policy.index? }
+
+    it { is_expected.to be(true) }
+  end
 
   describe '#show?' do
     subject { project_policy.show? }
-    
-    context 'with no role for for this project' do
-      it { is_expected.to be(false) }
-    end
 
-    context 'with an admin rolefor for this project' do
-      before do
-        create(:project_member, project: record, user: user, role: :admin)
-      end
-
-      it { is_expected.to be(true) }
-    end
-
-    context 'with a member rolefor this project' do
-      before do
-        create(:project_member, project: record, user: user, role: :member)
-      end
-
-      it { is_expected.to be(true) }
-    end
+    it { is_expected.to be(true) }
   end
 end

--- a/spec/policies/project_policy_spec.rb
+++ b/spec/policies/project_policy_spec.rb
@@ -5,6 +5,28 @@ RSpec.describe ProjectPolicy, type: :policy do
   let(:record) { create(:project) }
   let(:project_policy) { described_class.new(user, record) }
 
+  shared_examples 'an action available only to contributors' do
+    context 'with no role for for this project' do
+      it { is_expected.to be(false) }
+    end
+
+    context 'with an admin role for for this project' do
+      before do
+        create(:project_member, project: record, user: user, role: :admin)
+      end
+
+      it { is_expected.to be(true) }
+    end
+
+    context 'with a member rolefor this project' do
+      before do
+        create(:project_member, project: record, user: user, role: :member)
+      end
+
+      it { is_expected.to be(true) }
+    end
+  end
+
   describe '#create?' do
     subject { project_policy.create? }
 
@@ -42,24 +64,6 @@ RSpec.describe ProjectPolicy, type: :policy do
   describe '#update?' do
     subject { project_policy.update? }
     
-    context 'with no role for for this project' do
-      it { is_expected.to be(false) }
-    end
-
-    context 'with an admin rolefor for this project' do
-      before do
-        create(:project_member, project: record, user: user, role: :admin)
-      end
-
-      it { is_expected.to be(true) }
-    end
-
-    context 'with a member rolefor this project' do
-      before do
-        create(:project_member, project: record, user: user, role: :member)
-      end
-
-      it { is_expected.to be(true) }
-    end
+    it_behaves_like 'an action available only to contributors'
   end
 end

--- a/spec/policies/project_token_policy_spec.rb
+++ b/spec/policies/project_token_policy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe ProjectTokenPolicy, type: :policy do
+  let(:record) { create(:project_token) }
+
+  let(:non_member) { create(:user) }
+  let(:member) {
+    create(:project_member, project: record.project, role: :member).user
+  }
+  let(:admin) {
+    create(:project_member, project: record.project, role: :admin).user
+  }
+
+  describe 'all actions' do
+    %w(
+      create?
+    ).each do |action_name|
+      it "only project members can perform #{action_name}" do
+        aggregate_failures "testing users" do
+          expect(described_class.new(non_member, record).send(action_name)).to eq(false)
+          expect(described_class.new(member, record).send(action_name)).to eq(true)
+          expect(described_class.new(admin, record).send(action_name)).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/policies/revision_policy_spec.rb
+++ b/spec/policies/revision_policy_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe RevisionPolicy, type: :policy do
+  let(:record) { create(:revision) }
+  let(:user) { create(:user) }
+
+  describe 'all actions' do
+    %w(
+      index?
+      show?
+    ).each do |action_name|
+      it "anyone can perform #{action_name}" do
+        expect(described_class.new(user, record).send(action_name)).to eq(true)
+      end
+    end
+  end
+end

--- a/spec/policies/scenario_policy_spec.rb
+++ b/spec/policies/scenario_policy_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ScenarioPolicy, type: :policy do
+  let(:record) { create(:scenario) }
+
+  let(:non_member) { create(:user) }
+  let(:member) {
+    create(:project_member, project: record.project, role: :member).user
+  }
+  let(:admin) {
+    create(:project_member, project: record.project, role: :admin).user
+  }
+
+  describe 'all actions' do
+    %w(
+      create?
+      destroy?
+      index?
+      run?
+      show?
+      update?
+    ).each do |action_name|
+      it "only project members can perform #{action_name}" do
+        aggregate_failures "testing users" do
+          expect(described_class.new(non_member, record).send(action_name)).to eq(false)
+          expect(described_class.new(member, record).send(action_name)).to eq(true)
+          expect(described_class.new(admin, record).send(action_name)).to eq(true)
+        end
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove this line.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -54,4 +54,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.include Devise::Test::IntegrationHelpers, type: :request
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "Projects", type: :request do
+  describe "list projects" do
+    it 'succeeds' do
+      get projects_path
+      expect(response).to have_http_status(200)
+    end
+
+    context 'with some projects' do
+      let!(:projects) { create_list :project, 2, name: 'New Projects'}
+
+      it 'lists all projects' do
+        get projects_path
+        expect(response.body.scan('New Projects').size).to eq(2)
+      end
+    end
+  end
+end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -53,6 +53,35 @@ RSpec.describe "Projects", type: :request do
     end
   end
 
+  describe "edit project" do
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+
+    subject { get edit_project_path(project) }
+
+    before { sign_in user }
+
+    context 'without a membership for that user to that project' do
+      it 'fails' do
+        expect{ subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'with a membership for that user to that project' do
+      before { create(:project_member, role: :member, user: user, project: project) }
+
+      it 'succeeds' do
+        subject
+        expect(response).to have_http_status(200)
+      end
+
+      it 'displays the project form' do
+        subject
+        expect(response.body).to include("Edit Project #{project.id}")
+      end
+    end
+  end
+
   describe "update project" do
     let(:user) { create(:user) }
     let(:project) { create(:project) }
@@ -80,6 +109,22 @@ RSpec.describe "Projects", type: :request do
         subject
         expect(response.body).to include('Updated Project')
       end
+    end
+  end
+
+  describe "show project" do
+    let(:project) { create(:project, name: 'This Project') }
+
+    subject { get project_path(project) }
+
+    it 'succeeds' do
+      subject
+      expect(response).to have_http_status(200)
+    end
+
+    it 'displays the project details' do
+      subject
+      expect(response.body).to include('This Project')
     end
   end
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -16,4 +16,40 @@ RSpec.describe "Projects", type: :request do
       end
     end
   end
+
+  describe "new project" do
+    context 'with a logged in user' do
+      before { sign_in create(:user) }
+
+      it 'succeeds' do
+        get new_project_path
+        expect(response).to have_http_status(200)
+      end
+
+      it 'displays the project form' do
+        get new_project_path
+        expect(response.body).to include('Save')
+      end
+    end
+  end
+
+  describe "create project" do
+    let(:project_params) { { project: { name: 'My Project' }  } }
+
+    subject { post '/projects', params: project_params }
+
+    context 'with a logged in user' do
+      before { sign_in create(:user) }
+
+      it 'succeeds' do
+        subject
+        expect(response).to have_http_status(200)
+      end
+
+      it 'displays that project details' do
+        subject
+        expect(response.body).to include('My Project')
+      end
+    end
+  end
 end

--- a/spec/requests/projects_spec.rb
+++ b/spec/requests/projects_spec.rb
@@ -52,4 +52,34 @@ RSpec.describe "Projects", type: :request do
       end
     end
   end
+
+  describe "update project" do
+    let(:user) { create(:user) }
+    let(:project) { create(:project) }
+    let(:project_params) { { project: { name: 'Updated Project' }  } }
+
+    subject { put project_path(project), params: project_params }
+
+    before { sign_in user }
+
+    context 'without a membership for that user to that project' do
+      it 'fails' do
+        expect{ subject }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    context 'with a membership for that user to that project' do
+      before { create(:project_member, role: :member, user: user, project: project) }
+
+      it 'succeeds' do
+        subject
+        expect(response).to have_http_status(200)
+      end
+
+      it 'displays the updated project details' do
+        subject
+        expect(response.body).to include('Updated Project')
+      end
+    end
+  end
 end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,3 +1,7 @@
 RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
 end
+
+FactoryBot.define do
+  sequence(:email) { |n| "email#{n}@example.com" }
+end


### PR DESCRIPTION
This PR uses Pundit to authorize actions from the web forms. I've left all of the projects, revisions, and comparisons publically visible but restricted the scenario and project_tokens which are the keys to generating new revisions. Comparisons are currently "open" as well, but's mostly because they're lacking a user friendly interface anyways.

The API is the only other way to "change" a project by generating revisions, but it gets it's security from the API keys.